### PR TITLE
Language listener

### DIFF
--- a/lib/LocalizedStrings.d.ts
+++ b/lib/LocalizedStrings.d.ts
@@ -63,7 +63,7 @@ declare module "localized-strings" {
     /**
      * Listen to language changes
      */
-    addLanguageChangeListener: (callback: () => void) => void;
+    addLanguageChangeListener: (callback: (language: string) => void) => void;
 
     /**
      * Remove language listener

--- a/lib/LocalizedStrings.d.ts
+++ b/lib/LocalizedStrings.d.ts
@@ -58,7 +58,17 @@ declare module "localized-strings" {
     /**
      * Return current locale object
      */
-    getContent(): any
+    getContent(): any;
+
+    /**
+     * Listen to language changes
+     */
+    addLanguageChangeListener: (callback: () => void) => void;
+
+    /**
+     * Remove language listener
+     */
+    removeLanguageChangeListener: (callback: () => void) => void;
   }
 
   export type LocalizedStrings<T> = LocalizedStringsMethods & T;

--- a/lib/LocalizedStrings.js
+++ b/lib/LocalizedStrings.js
@@ -184,7 +184,7 @@ var LocalizedStrings = function () {
         }
       }
 
-      this._runLanguageListeners();
+      this._runLanguageListeners(bestLanguage);
     }
 
     /**
@@ -347,10 +347,10 @@ var LocalizedStrings = function () {
     }
   }, {
     key: "_runLanguageListeners",
-    value: function _runLanguageListeners() {
+    value: function _runLanguageListeners(language) {
       this._languageListeners.forEach(function (listener) {
         try {
-          listener();
+          listener(language);
         } catch (error) {
           /* no op */
         }

--- a/lib/LocalizedStrings.js
+++ b/lib/LocalizedStrings.js
@@ -53,6 +53,7 @@ var LocalizedStrings = function () {
   function LocalizedStrings(props, options) {
     _classCallCheck(this, LocalizedStrings);
 
+    this._languageListeners = [];
     // Compatibility fix with previous version
     if (typeof options === "function") {
       /* eslint-disable no-param-reassign */
@@ -182,6 +183,8 @@ var LocalizedStrings = function () {
           this._fallbackValues(localizedStrings, this);
         }
       }
+
+      this._runLanguageListeners();
     }
 
     /**
@@ -341,6 +344,39 @@ var LocalizedStrings = function () {
     key: "getContent",
     value: function getContent() {
       return this._props;
+    }
+  }, {
+    key: "_runLanguageListeners",
+    value: function _runLanguageListeners() {
+      this._languageListeners.forEach(function (listener) {
+        try {
+          listener();
+        } catch (error) {
+          /* no op */
+        }
+      });
+    }
+  }, {
+    key: "addLanguageChangeListener",
+    value: function addLanguageChangeListener(listener) {
+      this._languageListeners.push(listener);
+    }
+  }, {
+    key: "removeLanguageChangeListener",
+    value: function removeLanguageChangeListener(listener) {
+      var index = this._languageListeners.findIndex(function (a) {
+        return a === listener;
+      });
+
+      if (index === -1) {
+        console.log("Language listener does not exist", middleware);
+
+        return;
+      }
+
+      this._languageListeners = this._languageListeners.filter(function (_, _index) {
+        return _index !== index;
+      });
     }
   }]);
 

--- a/spec/LocalizedStrings.spec.js
+++ b/spec/LocalizedStrings.spec.js
@@ -305,7 +305,8 @@ describe("language listener", () => {
   });
 
   it("run listener", (done) => {
-    strings.addLanguageChangeListener(() => {
+    strings.addLanguageChangeListener((language) => {
+      expect(language).toBe("sv");
       done();
     });
 

--- a/spec/LocalizedStrings.spec.js
+++ b/spec/LocalizedStrings.spec.js
@@ -1,6 +1,6 @@
-import LocalizedStrings from '../lib/LocalizedStrings';
+import LocalizedStrings from "../lib/LocalizedStrings";
 
-describe('Main Library Functions', () => {
+describe("Main Library Functions", () => {
   /**
    * Load up language file to use during tests
    */
@@ -11,268 +11,304 @@ describe('Main Library Functions', () => {
     strings = new LocalizedStrings(
       {
         en: {
-          language: 'english',
-          how: 'How do you want your egg today?',
-          boiledEgg: 'Boiled egg',
-          softBoiledEgg: 'Soft-boiled egg',
-          choice: 'How to choose the egg',
+          language: "english",
+          how: "How do you want your egg today?",
+          boiledEgg: "Boiled egg",
+          softBoiledEgg: "Soft-boiled egg",
+          choice: "How to choose the egg",
           formattedValue: "I'd like some {0} and {1}, or just {0}",
           ratings: {
-            excellent: 'excellent',
-            good: 'good',
-            missingComplex: 'missing value',
+            excellent: "excellent",
+            good: "good",
+            missingComplex: "missing value",
           },
-          missing: 'missing value',
-          currentDate: 'The current date is {month} {day}, {year}!',
-          falsy: '{0} {1} {2} {3} {4} {5}',
-          empty: '',
-          reference: '$ref{ratings.excellent}',
-          referenceAdvanced: '$ref{falsy}',
+          missing: "missing value",
+          currentDate: "The current date is {month} {day}, {year}!",
+          falsy: "{0} {1} {2} {3} {4} {5}",
+          empty: "",
+          reference: "$ref{ratings.excellent}",
+          referenceAdvanced: "$ref{falsy}",
         },
         it: {
-          language: 'italian',
-          how: 'Come vuoi il tuo uovo oggi?',
-          boiledEgg: 'Uovo sodo',
-          softBoiledEgg: 'Uovo alla coque',
+          language: "italian",
+          how: "Come vuoi il tuo uovo oggi?",
+          boiledEgg: "Uovo sodo",
+          softBoiledEgg: "Uovo alla coque",
           choice: "Come scegliere l'uovo",
           ratings: {
-            excellent: 'eccellente',
-            good: 'buono',
+            excellent: "eccellente",
+            good: "buono",
           },
           formattedValue: "Vorrei un po' di {0} e {1}, o solo {0}",
-          currentDate: 'La data corrente è {month} {day}, {year}!',
-          falsy: '{0} {1} {2} {3} {4} {5}',
-          empty: '',
+          currentDate: "La data corrente è {month} {day}, {year}!",
+          falsy: "{0} {1} {2} {3} {4} {5}",
+          empty: "",
         },
       },
-      { logsEnabled: false },
+      { logsEnabled: false }
     );
   });
 
-  it('Set default language to en', () => {
-    expect(strings.getLanguage()).toEqual('en');
+  it("Set default language to en", () => {
+    expect(strings.getLanguage()).toEqual("en");
   });
 
-  it('List available languages', () => {
-    expect(strings.getAvailableLanguages()).toEqual(['en', 'it']);
+  it("List available languages", () => {
+    expect(strings.getAvailableLanguages()).toEqual(["en", "it"]);
   });
 
   // Default language
-  it('Extract simple value from default language', () => {
-    expect(strings.how).toEqual('How do you want your egg today?');
+  it("Extract simple value from default language", () => {
+    expect(strings.how).toEqual("How do you want your egg today?");
   });
-  it('Extract complex value from default language', () => {
-    expect(strings.ratings.good).toEqual('good');
+  it("Extract complex value from default language", () => {
+    expect(strings.ratings.good).toEqual("good");
   });
-  it('Get complex missing key from default language', () => {
-    expect(strings.ratings.missingComplex).toEqual('missing value');
+  it("Get complex missing key from default language", () => {
+    expect(strings.ratings.missingComplex).toEqual("missing value");
   });
-  it('Get missing key from default language', () => {
+  it("Get missing key from default language", () => {
     expect(strings.ratings.notfound).toBe(undefined);
   });
-  it('Format string in default language', () => {
+  it("Format string in default language", () => {
     expect(
-      strings.formatString(strings.formattedValue, 'cake', 'ice-cream'),
+      strings.formatString(strings.formattedValue, "cake", "ice-cream")
     ).toEqual("I'd like some cake and ice-cream, or just cake");
   });
 
   // Switch language
-  it('Switch language to italian', () => {
-    strings.setLanguage('it');
-    expect(strings.getLanguage()).toEqual('it');
+  it("Switch language to italian", () => {
+    strings.setLanguage("it");
+    expect(strings.getLanguage()).toEqual("it");
   });
-  it('Extract simple value from  other language', () => {
-    strings.setLanguage('it');
-    expect(strings.how).toEqual('Come vuoi il tuo uovo oggi?');
-  });
-
-  it('Extract complex value from other language', () => {
-    strings.setLanguage('it');
-    expect(strings.ratings.good).toEqual('buono');
+  it("Extract simple value from  other language", () => {
+    strings.setLanguage("it");
+    expect(strings.how).toEqual("Come vuoi il tuo uovo oggi?");
   });
 
-  it('Get missing key from other language', () => {
-    strings.setLanguage('it');
-    expect(strings.missing).toEqual('missing value');
+  it("Extract complex value from other language", () => {
+    strings.setLanguage("it");
+    expect(strings.ratings.good).toEqual("buono");
   });
 
-  it('Get complex missing key from other language', () => {
-    strings.setLanguage('it');
-    expect(strings.ratings.missingComplex).toEqual('missing value');
+  it("Get missing key from other language", () => {
+    strings.setLanguage("it");
+    expect(strings.missing).toEqual("missing value");
   });
 
-  it('Format string in other language', () => {
-    strings.setLanguage('it');
+  it("Get complex missing key from other language", () => {
+    strings.setLanguage("it");
+    expect(strings.ratings.missingComplex).toEqual("missing value");
+  });
+
+  it("Format string in other language", () => {
+    strings.setLanguage("it");
     expect(
-      strings.formatString(strings.formattedValue, 'torta', 'gelato'),
+      strings.formatString(strings.formattedValue, "torta", "gelato")
     ).toEqual("Vorrei un po' di torta e gelato, o solo torta");
   });
 
-  it('Get string in a different language', () => {
-    strings.setLanguage('it');
-    expect(strings.getString('choice', 'en')).toBe('How to choose the egg');
+  it("Get string in a different language", () => {
+    strings.setLanguage("it");
+    expect(strings.getString("choice", "en")).toBe("How to choose the egg");
   });
 
-  it('Switch to different props', () => {
+  it("Switch to different props", () => {
     strings.setContent({
       fr: {
-        hello: 'bonjour',
+        hello: "bonjour",
       },
       en: {
-        hello: 'hello',
+        hello: "hello",
       },
       it: {
-        hello: 'ciao',
+        hello: "ciao",
       },
     });
-    strings.setLanguage('fr');
-    expect(strings.hello).toEqual('bonjour');
+    strings.setLanguage("fr");
+    expect(strings.hello).toEqual("bonjour");
   });
 
-  it('Switch to different props with nested objects', () => {
+  it("Switch to different props with nested objects", () => {
     strings = new LocalizedStrings({
       en: {
         a: {
-          b: { x: 'foo', y: 'bar' },
-          c: { z: 'baz' },
+          b: { x: "foo", y: "bar" },
+          c: { z: "baz" },
         },
       },
     });
     strings.setContent({
       en: {
         a: {
-          b: { x: 'a.b.x', y: 'a.b.y' },
-          c: { z: 'a.c.z' },
+          b: { x: "a.b.x", y: "a.b.y" },
+          c: { z: "a.c.z" },
         },
       },
     });
-    strings.setLanguage('en');
-    expect(strings.a.b.x).toEqual('a.b.x');
+    strings.setLanguage("en");
+    expect(strings.a.b.x).toEqual("a.b.x");
   });
 
-  it('Should allow replacing a single language with the setContent method', () => {
+  it("Should allow replacing a single language with the setContent method", () => {
     strings = new LocalizedStrings({
       en: {
-        how: 'How do you want your egg today?',
-        boiledEgg: 'Boiled egg',
+        how: "How do you want your egg today?",
+        boiledEgg: "Boiled egg",
       },
       it: {
-        how: 'Come vuoi il tuo uovo oggi?',
-        boiledEgg: 'Uovo bollito',
+        how: "Come vuoi il tuo uovo oggi?",
+        boiledEgg: "Uovo bollito",
       },
     });
 
     strings.setContent(
       Object.assign({}, strings.getContent(), {
         en: {
-          how: 'How do you want your egg todajsie?',
-          boiledEgg: 'Boiled eggsie',
+          how: "How do you want your egg todajsie?",
+          boiledEgg: "Boiled eggsie",
         },
-      }),
+      })
     );
 
-    expect(strings.how).toEqual('How do you want your egg todajsie?');
-    strings.setLanguage('it');
-    expect(strings.how).toEqual('Come vuoi il tuo uovo oggi?');
+    expect(strings.how).toEqual("How do you want your egg todajsie?");
+    strings.setLanguage("it");
+    expect(strings.how).toEqual("Come vuoi il tuo uovo oggi?");
   });
 
-  it('Handles named tokens as part of the format string', () => {
+  it("Handles named tokens as part of the format string", () => {
     const formatTokens = {
-      month: 'January',
-      day: '12',
-      year: '2018',
+      month: "January",
+      day: "12",
+      year: "2018",
     };
     expect(strings.formatString(strings.currentDate, formatTokens)).toEqual(
-      'The current date is January 12, 2018!',
+      "The current date is January 12, 2018!"
     );
   });
 
-  it('Handles falsy values', () => {
+  it("Handles falsy values", () => {
     // falsy: "{0} {1} {2} {3} {4} {5}"
     expect(
-      strings.formatString(strings.falsy, 0, false, '', null, undefined, NaN),
-    ).toEqual([0, false, '', null, undefined, NaN].join(' '));
+      strings.formatString(strings.falsy, 0, false, "", null, undefined, NaN)
+    ).toEqual([0, false, "", null, undefined, NaN].join(" "));
   });
 
-  it('Handles empty values', () => {
+  it("Handles empty values", () => {
     expect(
       strings.formatString(strings.thisKeyDoesNotExist, {
-        thisReplacement: 'doesNotExist',
-      }),
-    ).toEqual('');
+        thisReplacement: "doesNotExist",
+      })
+    ).toEqual("");
   });
 
-  it('Handles empty strings', () => {
-    expect(strings.empty).toEqual('');
+  it("Handles empty strings", () => {
+    expect(strings.empty).toEqual("");
   });
 
   // Checks for reference
-  it('Handle reference values', () => {
+  it("Handle reference values", () => {
     // reference: '$ref{ratings.excellent}'
-    expect(strings.formatString(strings.reference)).toEqual('excellent');
+    expect(strings.formatString(strings.reference)).toEqual("excellent");
   });
-  it('Handle reference values and falsy', () => {
+  it("Handle reference values and falsy", () => {
     expect(
       strings.formatString(
         strings.referenceAdvanced,
         0,
         false,
-        '',
+        "",
         null,
         undefined,
-        NaN,
-      ),
-    ).toEqual([0, false, '', null, undefined, NaN].join(' '));
+        NaN
+      )
+    ).toEqual([0, false, "", null, undefined, NaN].join(" "));
   });
 });
 
-describe('use the default getInterfaceLanguageMethod', () => {
+describe("use the default getInterfaceLanguageMethod", () => {
   const strings = new LocalizedStrings(
     {
       en: {
-        language: 'english',
+        language: "english",
       },
       it: {
-        language: 'italian',
+        language: "italian",
       },
     },
-    { logsEnabled: false },
+    { logsEnabled: false }
   );
-  it('Use the default method that returns en-US', () => {
-    expect(strings.language).toBe('english');
+  it("Use the default method that returns en-US", () => {
+    expect(strings.language).toBe("english");
   });
 });
 
-describe('use a custom getInterfaceLanguageMethod', () => {
+describe("use a custom getInterfaceLanguageMethod", () => {
   const strings = new LocalizedStrings(
     {
       en: {
-        language: 'english',
+        language: "english",
       },
       it: {
-        language: 'italian',
+        language: "italian",
       },
     },
-    { customLanguageInterface: () => 'it-IT', logsEnabled: false },
+    { customLanguageInterface: () => "it-IT", logsEnabled: false }
   );
-  it('Use the custom method that returns it_IT', () => {
-    expect(strings.language).toBe('italian');
+  it("Use the custom method that returns it_IT", () => {
+    expect(strings.language).toBe("italian");
   });
-  it('Use the custom interface methods when checking the getInterfaceLanguage', () => {
-    expect(strings.getInterfaceLanguage()).toBe('it-IT');
+  it("Use the custom interface methods when checking the getInterfaceLanguage", () => {
+    expect(strings.getInterfaceLanguage()).toBe("it-IT");
   });
 });
 
-describe('use psuedo characters', () => {
+describe("use psuedo characters", () => {
   const strings = new LocalizedStrings(
     {
       en: {
-        language: 'english',
+        language: "english",
       },
     },
-    { pseudo: true, logsEnabled: false },
+    { pseudo: true, logsEnabled: false }
   );
-  it('Psuedo changed value', () => {
-    expect(strings.formatString('language')).not.toBe('english');
+  it("Psuedo changed value", () => {
+    expect(strings.formatString("language")).not.toBe("english");
+  });
+});
+
+describe("language listener", () => {
+  const strings = new LocalizedStrings(
+    {
+      en: {
+        language: "english",
+      },
+      sv: {
+        language: "swedish",
+      },
+    },
+    { pseudo: true, logsEnabled: false }
+  );
+
+  const listener = () => {};
+
+  it("set listener", () => {
+    strings.addLanguageChangeListener(listener);
+
+    expect(strings._languageListeners).toHaveSize(1);
+  });
+
+  it("remove listener", () => {
+    strings.removeLanguageChangeListener(listener);
+
+    expect(strings._languageListeners).toHaveSize(0);
+  });
+
+  it("run listener", (done) => {
+    strings.addLanguageChangeListener(() => {
+      done();
+    });
+
+    strings.setLanguage("sv");
   });
 });

--- a/src/LocalizedStrings.js
+++ b/src/LocalizedStrings.js
@@ -149,7 +149,7 @@ export default class LocalizedStrings {
       }
     }
 
-    this._runLanguageListeners();
+    this._runLanguageListeners(bestLanguage);
   }
 
   /**
@@ -293,10 +293,10 @@ export default class LocalizedStrings {
     return this._props;
   }
 
-  _runLanguageListeners() {
+  _runLanguageListeners(language) {
     this._languageListeners.forEach((listener) => {
       try {
-        listener();
+        listener(language);
       } catch (error) {
         /* no op */
       }


### PR DESCRIPTION
Problem: react components does not re-render when language is changed and localisations should be switched. This is not much of a problem for the widget that stores language code i redux and components re-renders from that. But for example, form-renderer has no state management and needs some way of updating components when language changes.

added these api:s `addLanguageChangeListener`, `removeLanguageChangeListener`. Tests are written and can be viewed in spec folder. With this listener a custom hook can be written.

Usage:
```typescript
strings.addLanguageChangeListener((language: string) => {
  console.log(language === 'sv') // true
});

strings.setLanguage("sv");
```

_i awkwardly made the first [pr](https://github.com/stefalda/localized-strings/pull/29) to the original repository..._